### PR TITLE
Add basic customization options

### DIFF
--- a/src/main/java/com/acair/acairsoriginssecundus/acairsoriginssecundus/Acairsoriginssecundus.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/acairsoriginssecundus/Acairsoriginssecundus.java
@@ -14,6 +14,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
+import com.acair.acairsoriginssecundus.client.KeyBindings;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -72,6 +73,9 @@ public class Acairsoriginssecundus {
 
         // Register ourselves for server and other game events we are interested in
         MinecraftForge.EVENT_BUS.register(this);
+        // Подписываем обработчики горячих клавиш на нужные шины событий
+        modEventBus.addListener(KeyBindings::register); // регистрация клавиш
+        MinecraftForge.EVENT_BUS.addListener(KeyBindings::onClientTick); // проверка нажатий
 
         // Register the item to a creative tab
         modEventBus.addListener(this::addCreative);

--- a/src/main/java/com/acair/acairsoriginssecundus/character/EarType.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/character/EarType.java
@@ -1,0 +1,23 @@
+package com.acair.acairsoriginssecundus.character;
+
+import net.minecraft.network.chat.Component;
+
+/**
+ * Тип ушей используется для рас,
+ * которым доступна подобная настройка
+ * (например, эльфам).
+ */
+public enum EarType {
+    HUMAN("ear_type.acairsoriginssecundus.human"),
+    POINTED("ear_type.acairsoriginssecundus.pointed");
+
+    private final String key;
+
+    EarType(String key) {
+        this.key = key;
+    }
+
+    public Component getName() {
+        return Component.translatable(this.key);
+    }
+}

--- a/src/main/java/com/acair/acairsoriginssecundus/character/EyeColor.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/character/EyeColor.java
@@ -1,0 +1,26 @@
+package com.acair.acairsoriginssecundus.character;
+
+import net.minecraft.network.chat.Component;
+
+/**
+ * Цвет глаз персонажа. Используется в редакторе
+ * для выбора из доступных вариантов.
+ */
+public enum EyeColor {
+    BROWN("eye_color.acairsoriginssecundus.brown"),
+    GREEN("eye_color.acairsoriginssecundus.green"),
+    BLUE("eye_color.acairsoriginssecundus.blue");
+
+    private final String key;
+
+    EyeColor(String key) {
+        this.key = key;
+    }
+
+    /**
+     * @return локализованное название цвета
+     */
+    public Component getName() {
+        return Component.translatable(this.key);
+    }
+}

--- a/src/main/java/com/acair/acairsoriginssecundus/character/Race.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/character/Race.java
@@ -1,0 +1,28 @@
+package com.acair.acairsoriginssecundus.character;
+
+import net.minecraft.network.chat.Component;
+
+/**
+ * Перечисление рас для персонажей. Каждая раса содержит
+ * название и описание для отображения в интерфейсе.
+ */
+public enum Race {
+    HUMAN("race.acairsoriginssecundus.human", "race.acairsoriginssecundus.human.desc"),
+    ELF("race.acairsoriginssecundus.elf", "race.acairsoriginssecundus.elf.desc");
+
+    private final String nameKey;
+    private final String descriptionKey;
+
+    Race(String nameKey, String descriptionKey) {
+        this.nameKey = nameKey;
+        this.descriptionKey = descriptionKey;
+    }
+
+    public Component getName() {
+        return Component.translatable(this.nameKey);
+    }
+
+    public Component getDescription() {
+        return Component.translatable(this.descriptionKey);
+    }
+}

--- a/src/main/java/com/acair/acairsoriginssecundus/client/KeyBindings.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/client/KeyBindings.java
@@ -1,0 +1,54 @@
+package com.acair.acairsoriginssecundus.client;
+
+import com.acair.acairsoriginssecundus.client.screen.RaceSelectScreen;
+import com.acair.acairsoriginssecundus.acairsoriginssecundus.Acairsoriginssecundus;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.common.util.Lazy;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.lwjgl.glfw.GLFW;
+import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
+
+/**
+ * Класс для регистрации и обработки горячих клавиш клиента.
+ * Используем один биндинг для открытия экрана выбора расы.
+ *
+ * <p>Аннотация ниже указывает, что обработчики этого класса
+ * слушают события на основной шине Forge только на клиенте.
+ * Событие регистрации клавиш {@link RegisterKeyMappingsEvent}
+ * отправляется на мод-шину, поэтому соответствующий метод
+ * подключается к ней в конструкторе мода.</p>
+ */
+@Mod.EventBusSubscriber(modid = Acairsoriginssecundus.MODID,
+        bus = Mod.EventBusSubscriber.Bus.FORGE,
+        value = Dist.CLIENT)
+public class KeyBindings {
+    // Горячая клавиша лениво инициализируется при регистрации
+    public static final Lazy<KeyMapping> OPEN_EDITOR = Lazy.of(() -> new KeyMapping(
+            "key.acairsoriginssecundus.open_editor",
+            GLFW.GLFW_KEY_O,
+            "key.categories.acairsoriginssecundus"
+    ));
+
+    @SubscribeEvent
+    public static void register(RegisterKeyMappingsEvent event) {
+        event.register(OPEN_EDITOR.get());
+    }
+
+    @SubscribeEvent
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase == TickEvent.Phase.END) {
+            while (OPEN_EDITOR.get().consumeClick()) {
+                Minecraft mc = Minecraft.getInstance();
+                Screen current = mc.screen;
+                if (!(current instanceof RaceSelectScreen)) {
+                    mc.setScreen(new RaceSelectScreen());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/acair/acairsoriginssecundus/client/screen/CharacterEditorScreen.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/client/screen/CharacterEditorScreen.java
@@ -1,0 +1,85 @@
+package com.acair.acairsoriginssecundus.client.screen;
+
+import com.acair.acairsoriginssecundus.character.Race;
+import com.acair.acairsoriginssecundus.character.EyeColor;
+import com.acair.acairsoriginssecundus.character.EarType;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.AbstractSliderButton;
+import net.minecraft.client.gui.components.CycleButton;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Экран редактора персонажа. Здесь размещены простые
+ * элементы управления для изменения параметров.
+ */
+public class CharacterEditorScreen extends Screen {
+    private final Race race;
+    private AbstractSliderButton heightSlider;
+    // Кнопка для выбора цвета глаз
+    private CycleButton<EyeColor> eyeColor;
+    // Кнопка для выбора типа ушей, только для некоторых рас
+    private CycleButton<EarType> earType;
+    private Button back;
+    private Button done;
+
+    public CharacterEditorScreen(Race race) {
+        super(Component.translatable("screen.acairsoriginssecundus.editor"));
+        this.race = race;
+    }
+
+    @Override
+    protected void init() {
+        int centerX = this.width / 2;
+        int centerY = this.height / 2;
+        // Простой слайдер для роста персонажа
+        this.heightSlider = new AbstractSliderButton(centerX - 100, centerY - 20, 200, 20, Component.translatable("option.acairsoriginssecundus.height"), 0.5) {
+            @Override
+            protected void updateMessage() {
+                setMessage(Component.translatable("option.acairsoriginssecundus.height", String.format("%.2f", this.value)));
+            }
+
+            @Override
+            protected void applyValue() {
+                // Здесь можно сохранить значение в конфигурацию игрока
+            }
+        };
+        this.addRenderableWidget(this.heightSlider);
+
+        // Переключатель цвета глаз
+        this.eyeColor = this.addRenderableWidget(
+                CycleButton.builder(EyeColor::getName)
+                        .withValues(EyeColor.values())
+                        .create(centerX - 100, centerY + 10, 200, 20,
+                                Component.translatable("option.acairsoriginssecundus.eye_color")));
+
+        // Если раса поддерживает выбор типа ушей, добавляем соответствующий переключатель
+        if (this.race == Race.ELF) {
+            this.earType = this.addRenderableWidget(
+                    CycleButton.builder(EarType::getName)
+                            .withValues(EarType.values())
+                            .create(centerX - 100, centerY + 40, 200, 20,
+                                    Component.translatable("option.acairsoriginssecundus.ear_type")));
+        }
+
+        // Кнопки навигации
+        this.back = this.addRenderableWidget(Button.builder(Component.translatable("gui.back"),
+                b -> this.minecraft.setScreen(new RaceSelectScreen()))
+                .bounds(centerX - 100, centerY + 70, 80, 20).build());
+        this.done = this.addRenderableWidget(Button.builder(Component.translatable("gui.done"),
+                b -> this.minecraft.setScreen(null))
+                .bounds(centerX + 20, centerY + 70, 80, 20).build());
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        this.renderBackground(graphics);
+        int centerX = this.width / 2;
+        int centerY = this.height / 2;
+        // Заголовок с выбранной расой
+        graphics.drawCenteredString(this.font, this.race.getName(), centerX, centerY - 60, 0xFFFFFF);
+        super.render(graphics, mouseX, mouseY, partialTick);
+    }
+}

--- a/src/main/java/com/acair/acairsoriginssecundus/client/screen/RaceSelectScreen.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/client/screen/RaceSelectScreen.java
@@ -1,0 +1,67 @@
+package com.acair.acairsoriginssecundus.client.screen;
+
+import com.acair.acairsoriginssecundus.character.Race;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import net.minecraft.network.chat.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Экран выбора расы. Слева отображается модель игрока,
+ * справа описание выбранной расы. Стрелками можно
+ * переключать расы, а кнопка "Готово" подтверждает выбор
+ * и открывает экран редактора персонажа.
+ */
+public class RaceSelectScreen extends Screen {
+    private final List<Race> races = Arrays.asList(Race.values());
+    private int index = 0;
+    private Button left;
+    private Button right;
+    private Button done;
+
+    public RaceSelectScreen() {
+        super(Component.translatable("screen.acairsoriginssecundus.select_race"));
+    }
+
+    @Override
+    protected void init() {
+        int centerX = this.width / 2;
+        int centerY = this.height / 2;
+        // Кнопки для переключения рас
+        this.left = this.addRenderableWidget(Button.builder(Component.literal("<"), b -> this.cycle(-1))
+                .bounds(centerX - 70, centerY - 20, 20, 20).build());
+        this.right = this.addRenderableWidget(Button.builder(Component.literal(">"), b -> this.cycle(1))
+                .bounds(centerX + 50, centerY - 20, 20, 20).build());
+        // Кнопка подтверждения выбора
+        this.done = this.addRenderableWidget(Button.builder(Component.translatable("gui.done"), b -> this.confirm())
+                .bounds(centerX - 50, centerY + 40, 100, 20).build());
+    }
+
+    private void cycle(int dir) {
+        this.index = (this.index + dir + this.races.size()) % this.races.size();
+    }
+
+    private void confirm() {
+        this.minecraft.setScreen(new CharacterEditorScreen(this.races.get(this.index)));
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        this.renderBackground(graphics);
+        int centerX = this.width / 2;
+        int centerY = this.height / 2;
+        Race current = this.races.get(this.index);
+        // Отрисовка модели игрока слева
+        InventoryScreen.renderEntityInInventoryFollowsMouse(graphics, centerX - 90, centerY + 30, 30,
+                (float)(centerX - 90) - mouseX, (float)(centerY + 30 - 60) - mouseY, Minecraft.getInstance().player);
+        // Отрисовка названия и описания расы справа
+        graphics.drawCenteredString(this.font, current.getName(), centerX, centerY - 60, 0xFFFFFF);
+        graphics.drawWordWrap(this.font, current.getDescription(), centerX + 40, centerY - 20, 120, 0xFFFFFF);
+        super.render(graphics, mouseX, mouseY, partialTick);
+    }
+}

--- a/src/main/resources/assets/acairsoriginssecundus/lang/en_us.json
+++ b/src/main/resources/assets/acairsoriginssecundus/lang/en_us.json
@@ -1,0 +1,18 @@
+{
+  "race.acairsoriginssecundus.human": "Human",
+  "race.acairsoriginssecundus.human.desc": "Ordinary human being.",
+  "race.acairsoriginssecundus.elf": "Elf",
+  "race.acairsoriginssecundus.elf.desc": "Graceful forest dweller.",
+  "screen.acairsoriginssecundus.select_race": "Select Race",
+  "screen.acairsoriginssecundus.editor": "Character Editor",
+  "option.acairsoriginssecundus.height": "Height: %s",
+  "option.acairsoriginssecundus.eye_color": "Eye Color",
+  "option.acairsoriginssecundus.ear_type": "Ear Type",
+  "eye_color.acairsoriginssecundus.brown": "Brown",
+  "eye_color.acairsoriginssecundus.green": "Green",
+  "eye_color.acairsoriginssecundus.blue": "Blue",
+  "ear_type.acairsoriginssecundus.human": "Human",
+  "ear_type.acairsoriginssecundus.pointed": "Pointed",
+  "key.categories.acairsoriginssecundus": "Acair Origins",
+  "key.acairsoriginssecundus.open_editor": "Open Character Editor"
+}


### PR DESCRIPTION
## Summary
- add enums for eye color and ear type
- implement selection of eye color and ear type in `CharacterEditorScreen`
- localize new options in English

## Testing
- `sh gradlew test --no-daemon --console=plain` *(failed: Daemon stopped before running tests)*

------
https://chatgpt.com/codex/tasks/task_e_6842e30b647c832eb32f87939b3a042d