### PR TITLE
Improve race selection interface

### DIFF
--- a/src/main/java/com/acair/acairsoriginssecundus/acairsoriginssecundus/Acairsoriginssecundus.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/acairsoriginssecundus/Acairsoriginssecundus.java
@@ -14,6 +14,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
+import com.acair.acairsoriginssecundus.client.KeyBindings;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -72,6 +73,9 @@ public class Acairsoriginssecundus {
 
         // Register ourselves for server and other game events we are interested in
         MinecraftForge.EVENT_BUS.register(this);
+        // Подписываем обработчики горячих клавиш на нужные шины событий
+        modEventBus.addListener(KeyBindings::register); // регистрация клавиш
+        MinecraftForge.EVENT_BUS.addListener(KeyBindings::onClientTick); // проверка нажатий
 
         // Register the item to a creative tab
         modEventBus.addListener(this::addCreative);

--- a/src/main/java/com/acair/acairsoriginssecundus/character/EarType.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/character/EarType.java
@@ -1,0 +1,23 @@
+package com.acair.acairsoriginssecundus.character;
+
+import net.minecraft.network.chat.Component;
+
+/**
+ * Тип ушей используется для рас,
+ * которым доступна подобная настройка
+ * (например, эльфам).
+ */
+public enum EarType {
+    HUMAN("ear_type.acairsoriginssecundus.human"),
+    POINTED("ear_type.acairsoriginssecundus.pointed");
+
+    private final String key;
+
+    EarType(String key) {
+        this.key = key;
+    }
+
+    public Component getName() {
+        return Component.translatable(this.key);
+    }
+}

--- a/src/main/java/com/acair/acairsoriginssecundus/character/EyeColor.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/character/EyeColor.java
@@ -1,0 +1,26 @@
+package com.acair.acairsoriginssecundus.character;
+
+import net.minecraft.network.chat.Component;
+
+/**
+ * Цвет глаз персонажа. Используется в редакторе
+ * для выбора из доступных вариантов.
+ */
+public enum EyeColor {
+    BROWN("eye_color.acairsoriginssecundus.brown"),
+    GREEN("eye_color.acairsoriginssecundus.green"),
+    BLUE("eye_color.acairsoriginssecundus.blue");
+
+    private final String key;
+
+    EyeColor(String key) {
+        this.key = key;
+    }
+
+    /**
+     * @return локализованное название цвета
+     */
+    public Component getName() {
+        return Component.translatable(this.key);
+    }
+}

--- a/src/main/java/com/acair/acairsoriginssecundus/character/Race.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/character/Race.java
@@ -1,0 +1,28 @@
+package com.acair.acairsoriginssecundus.character;
+
+import net.minecraft.network.chat.Component;
+
+/**
+ * Перечисление рас для персонажей. Каждая раса содержит
+ * название и описание для отображения в интерфейсе.
+ */
+public enum Race {
+    HUMAN("race.acairsoriginssecundus.human", "race.acairsoriginssecundus.human.desc"),
+    ELF("race.acairsoriginssecundus.elf", "race.acairsoriginssecundus.elf.desc");
+
+    private final String nameKey;
+    private final String descriptionKey;
+
+    Race(String nameKey, String descriptionKey) {
+        this.nameKey = nameKey;
+        this.descriptionKey = descriptionKey;
+    }
+
+    public Component getName() {
+        return Component.translatable(this.nameKey);
+    }
+
+    public Component getDescription() {
+        return Component.translatable(this.descriptionKey);
+    }
+}

--- a/src/main/java/com/acair/acairsoriginssecundus/client/KeyBindings.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/client/KeyBindings.java
@@ -1,0 +1,53 @@
+package com.acair.acairsoriginssecundus.client;
+
+import com.acair.acairsoriginssecundus.client.screen.RaceSelectScreen;
+import com.acair.acairsoriginssecundus.acairsoriginssecundus.Acairsoriginssecundus;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.common.util.Lazy;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.lwjgl.glfw.GLFW;
+import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
+
+/**
+ * Класс для регистрации и обработки горячих клавиш клиента.
+ * Используем один биндинг для открытия экрана выбора расы.
+ *
+ * <p>Аннотация ниже указывает, что обработчики этого класса
+ * слушают события на основной шине Forge только на клиенте.
+ * Событие регистрации клавиш {@link RegisterKeyMappingsEvent}
+ * отправляется на мод-шину, поэтому соответствующий метод
+ * подключается к ней в конструкторе мода.</p>
+ */
+// Мы регистрируем обработчики событий вручную в конструкторе мода,
+// поэтому аннотация EventBusSubscriber здесь не требуется.
+public class KeyBindings {
+    // Горячая клавиша лениво инициализируется при регистрации
+    public static final Lazy<KeyMapping> OPEN_EDITOR = Lazy.of(() -> new KeyMapping(
+            "key.acairsoriginssecundus.open_editor",
+            GLFW.GLFW_KEY_O,
+            "key.categories.acairsoriginssecundus"
+    ));
+
+    @SubscribeEvent
+    public static void register(RegisterKeyMappingsEvent event) {
+        event.register(OPEN_EDITOR.get());
+    }
+
+    @SubscribeEvent
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase == TickEvent.Phase.END) {
+            while (OPEN_EDITOR.get().consumeClick()) {
+                Minecraft mc = Minecraft.getInstance();
+                Screen current = mc.screen;
+                if (!(current instanceof RaceSelectScreen)) {
+                    mc.setScreen(new RaceSelectScreen());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/acair/acairsoriginssecundus/client/screen/CharacterEditorScreen.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/client/screen/CharacterEditorScreen.java
@@ -1,0 +1,102 @@
+package com.acair.acairsoriginssecundus.client.screen;
+
+import com.acair.acairsoriginssecundus.character.EarType;
+import com.acair.acairsoriginssecundus.character.EyeColor;
+import com.acair.acairsoriginssecundus.character.Race;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractSliderButton;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.CycleButton;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import net.minecraft.network.chat.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Экран редактора персонажа. Отличается от экрана выбора
+ * рас только тем, что справа вместо описания располагаются
+ * элементы настройки модели.
+ */
+public class CharacterEditorScreen extends Screen {
+    private final List<Race> races = Arrays.asList(Race.values());
+    private final Race initialRace;
+    private RaceList raceList;
+
+    private AbstractSliderButton heightSlider;
+    private CycleButton<EyeColor> eyeColor;
+    private CycleButton<EarType> earType;
+    private Button back;
+    private Button done;
+
+    public CharacterEditorScreen(Race race) {
+        super(Component.translatable("screen.acairsoriginssecundus.editor"));
+        this.initialRace = race;
+    }
+
+    @Override
+    protected void init() {
+        int listWidth = 80;
+        // Полоска прокрутки рас располагается слева, как и на предыдущем экране
+        this.raceList = new RaceList(this.minecraft, 20, 20, listWidth, this.height - 40, races);
+        this.raceList.setSelectedRace(this.initialRace);
+        this.addRenderableWidget(this.raceList);
+
+        int editorLeft = this.width / 2 + 40;
+        int editorTop = this.height / 2 - 30;
+
+        // Слайдер высоты персонажа
+        this.heightSlider = new AbstractSliderButton(editorLeft, editorTop, 120, 20,
+                Component.translatable("option.acairsoriginssecundus.height"), 0.5) {
+            @Override
+            protected void updateMessage() {
+                setMessage(Component.translatable("option.acairsoriginssecundus.height", String.format("%.2f", value)));
+            }
+
+            @Override
+            protected void applyValue() {
+                // Здесь сохраняем выбранное значение при необходимости
+            }
+        };
+        this.addRenderableWidget(this.heightSlider);
+
+        // Выбор цвета глаз
+        this.eyeColor = this.addRenderableWidget(
+                CycleButton.builder(EyeColor::getName)
+                        .withValues(EyeColor.values())
+                        .create(editorLeft, editorTop + 25, 120, 20,
+                                Component.translatable("option.acairsoriginssecundus.eye_color")));
+
+        if (this.initialRace == Race.ELF) {
+            // У эльфов доступен выбор типа ушей
+            this.earType = this.addRenderableWidget(
+                    CycleButton.builder(EarType::getName)
+                            .withValues(EarType.values())
+                            .create(editorLeft, editorTop + 50, 120, 20,
+                                    Component.translatable("option.acairsoriginssecundus.ear_type")));
+        }
+
+        // Кнопки "Назад" и "Готово"
+        this.back = this.addRenderableWidget(Button.builder(Component.translatable("gui.back"),
+                b -> this.minecraft.setScreen(new RaceSelectScreen()))
+                .bounds(editorLeft, this.height - 30, 50, 20).build());
+        this.done = this.addRenderableWidget(Button.builder(Component.translatable("gui.done"),
+                b -> this.minecraft.setScreen(null))
+                .bounds(editorLeft + 70, this.height - 30, 50, 20).build());
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        this.renderDirtBackground(graphics);
+
+        // Модель игрока по центру и немного увеличенного размера
+        int modelX = this.width / 2 - 30;
+        int modelY = this.height / 2 + 40;
+        InventoryScreen.renderEntityInInventoryFollowsMouse(graphics, modelX, modelY, 50,
+                modelX - mouseX, modelY - 50 - mouseY, Minecraft.getInstance().player);
+
+        super.render(graphics, mouseX, mouseY, partialTick);
+    }
+}

--- a/src/main/java/com/acair/acairsoriginssecundus/client/screen/RaceList.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/client/screen/RaceList.java
@@ -1,0 +1,72 @@
+package com.acair.acairsoriginssecundus.client.screen;
+
+import com.acair.acairsoriginssecundus.character.Race;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraftforge.client.gui.widget.ScrollPanel;
+import com.mojang.blaze3d.vertex.Tesselator;
+import net.minecraft.network.chat.Component;
+
+import java.util.List;
+
+/**
+ * Простой список рас с возможностью прокрутки.
+ * Использует ScrollPanel из Forge для реализации полосы прокрутки.
+ */
+public class RaceList extends ScrollPanel {
+    private final List<Race> races;
+    private int selected;
+
+    public RaceList(Minecraft mc, int left, int top, int width, int height, List<Race> races) {
+        super(mc, width, height, top, left);
+        this.races = races;
+    }
+
+    /**
+     * Устанавливает текущий выбранный индекс согласно переданной расе.
+     */
+    public void setSelectedRace(Race race) {
+        this.selected = races.indexOf(race);
+    }
+
+    /**
+     * Возвращает выбранную расу.
+     */
+    public Race getSelectedRace() {
+        if (selected < 0 || selected >= races.size()) {
+            return races.get(0);
+        }
+        return races.get(selected);
+    }
+
+    @Override
+    protected int getContentHeight() {
+        // Высота всего содержимого равна количеству строк умножить на высоту шрифта
+        Font font = Minecraft.getInstance().font;
+        return races.size() * (font.lineHeight + 4);
+    }
+
+    @Override
+    protected void drawPanel(GuiGraphics graphics, int entryRight, int relativeY, Tesselator tess, int mouseX, int mouseY) {
+        Font font = Minecraft.getInstance().font;
+        int y = relativeY;
+        for (int i = 0; i < races.size(); i++) {
+            Component name = races.get(i).getName();
+            int color = (i == selected) ? 0xFFFFA0 : 0xFFFFFF;
+            graphics.drawString(font, name, this.left + 4, y, color, false);
+            y += font.lineHeight + 4;
+        }
+    }
+
+    @Override
+    protected boolean clickPanel(double mouseX, double mouseY, int button) {
+        Font font = Minecraft.getInstance().font;
+        int index = (int)(mouseY / (font.lineHeight + 4));
+        if (index >= 0 && index < races.size()) {
+            this.selected = index;
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/acair/acairsoriginssecundus/client/screen/RaceSelectScreen.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/client/screen/RaceSelectScreen.java
@@ -1,0 +1,66 @@
+package com.acair.acairsoriginssecundus.client.screen;
+
+import com.acair.acairsoriginssecundus.character.Race;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import net.minecraft.network.chat.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Экран выбора расы. Слева расположен список всех рас,
+ * позволяющий быстро пролистывать варианты. В центре
+ * отображается модель игрока, а справа блок с названием
+ * и описанием выбранной расы.
+ */
+public class RaceSelectScreen extends Screen {
+    private final List<Race> races = Arrays.asList(Race.values());
+    private RaceList raceList;
+    private Button done;
+
+    public RaceSelectScreen() {
+        super(Component.translatable("screen.acairsoriginssecundus.select_race"));
+    }
+
+    @Override
+    protected void init() {
+        int listWidth = 80;
+        // Создаём полоску прокрутки со списком рас
+        this.raceList = new RaceList(this.minecraft, 20, 20, listWidth, this.height - 40, races);
+        this.addRenderableWidget(this.raceList);
+
+        // Кнопка подтверждения выбора находится снизу по центру
+        this.done = this.addRenderableWidget(Button.builder(Component.translatable("gui.done"), b -> confirm())
+                .bounds(this.width / 2 - 50, this.height - 30, 100, 20).build());
+    }
+
+    private void confirm() {
+        // Переходим к экрану редактора с выбранной расой
+        this.minecraft.setScreen(new CharacterEditorScreen(this.raceList.getSelectedRace()));
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        // Фон как при загрузке мира
+        this.renderDirtBackground(graphics);
+
+        Race current = this.raceList.getSelectedRace();
+        int modelX = this.width / 2 - 30; // модель ближе к центру
+        int modelY = this.height / 2 + 40;
+
+        // Немного увеличиваем размер модели
+        InventoryScreen.renderEntityInInventoryFollowsMouse(graphics, modelX, modelY, 50,
+                modelX - mouseX, modelY - 50 - mouseY, Minecraft.getInstance().player);
+
+        // Блок с описанием справа
+        int infoLeft = this.width / 2 + 40;
+        graphics.drawString(this.font, current.getName(), infoLeft, 40, 0xFFFFFF, false);
+        graphics.drawWordWrap(this.font, current.getDescription(), infoLeft, 60, 120, 0xFFFFFF);
+
+        super.render(graphics, mouseX, mouseY, partialTick);
+    }
+}

--- a/src/main/resources/assets/acairsoriginssecundus/lang/en_us.json
+++ b/src/main/resources/assets/acairsoriginssecundus/lang/en_us.json
@@ -1,0 +1,18 @@
+{
+  "race.acairsoriginssecundus.human": "Human",
+  "race.acairsoriginssecundus.human.desc": "Ordinary human being.",
+  "race.acairsoriginssecundus.elf": "Elf",
+  "race.acairsoriginssecundus.elf.desc": "Graceful forest dweller.",
+  "screen.acairsoriginssecundus.select_race": "Select Race",
+  "screen.acairsoriginssecundus.editor": "Character Editor",
+  "option.acairsoriginssecundus.height": "Height: %s",
+  "option.acairsoriginssecundus.eye_color": "Eye Color",
+  "option.acairsoriginssecundus.ear_type": "Ear Type",
+  "eye_color.acairsoriginssecundus.brown": "Brown",
+  "eye_color.acairsoriginssecundus.green": "Green",
+  "eye_color.acairsoriginssecundus.blue": "Blue",
+  "ear_type.acairsoriginssecundus.human": "Human",
+  "ear_type.acairsoriginssecundus.pointed": "Pointed",
+  "key.categories.acairsoriginssecundus": "Acair Origins",
+  "key.acairsoriginssecundus.open_editor": "Open Character Editor"
+}


### PR DESCRIPTION
## Summary
- add `RaceList` widget using Forge `ScrollPanel`
- redesign `RaceSelectScreen` with scrolling race list, dirt background and larger player model
- rebuild `CharacterEditorScreen` to place customization controls on the right with race list on the left

## Testing
- `./gradlew test --no-daemon --console=plain` *(failed while downloading mappings)*

------
https://chatgpt.com/codex/tasks/task_e_6842e30b647c832eb32f87939b3a042d