### PR TITLE
Add basic character editor screen

### DIFF
--- a/src/main/java/com/acair/acairsoriginssecundus/AcairsOriginsSecundus.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/AcairsOriginsSecundus.java
@@ -1,4 +1,36 @@
 package com.acair.acairsoriginssecundus;
 
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.acair.acairsoriginssecundus.client.AOSClient;
+
+/**
+ * Основной класс мода. Здесь происходит регистрация событий и
+ * инициализация клиентской части при необходимости.
+ */
+@Mod(AcairsOriginsSecundus.MODID)
 public class AcairsOriginsSecundus {
+
+    public static final String MODID = "acairsoriginssecundus";
+    public static final Logger LOGGER = LogManager.getLogger();
+
+    public AcairsOriginsSecundus() {
+        LOGGER.info("Acair's Origins Secundus initializing");
+        IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
+        // Клиентскую инициализацию выполняем только на клиенте
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> modBus.addListener(this::clientSetup));
+    }
+
+    private void clientSetup(final FMLClientSetupEvent event) {
+        // В клиентскую инициализацию ничего не помещаем, она нужна только чтобы
+        // гарантировать загрузку класса AOSClient и его подписок на события
+        AOSClient.OPEN_EDITOR_KEY.get();
+    }
 }

--- a/src/main/java/com/acair/acairsoriginssecundus/client/AOSClient.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/client/AOSClient.java
@@ -1,0 +1,47 @@
+package com.acair.acairsoriginssecundus.client;
+
+import com.acair.acairsoriginssecundus.AcairsOriginsSecundus;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.common.util.Lazy;
+import com.mojang.blaze3d.platform.InputConstants;
+import org.lwjgl.glfw.GLFW;
+
+/**
+ * Класс с клиентскими обработчиками событий: регистрация
+ * клавиш и открытие экрана редактора персонажа.
+ */
+@Mod.EventBusSubscriber(modid = AcairsOriginsSecundus.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
+public class AOSClient {
+
+    // Лениво создаем KeyMapping. Клавиша по умолчанию - O.
+    public static final Lazy<KeyMapping> OPEN_EDITOR_KEY = Lazy.of(() ->
+            new KeyMapping("key.acairsoriginssecundus.open_editor", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_O,
+                    "key.categories.acairsoriginssecundus"));
+
+    // Регистрируем клавишу через событие RegisterKeyMappingsEvent
+    @SubscribeEvent
+    public static void registerBindings(RegisterKeyMappingsEvent event) {
+        event.register(OPEN_EDITOR_KEY.get());
+    }
+
+    // Отслеживаем нажатие клавиши каждый тик клиента
+    @SubscribeEvent
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase == TickEvent.Phase.END) {
+            while (OPEN_EDITOR_KEY.get().consumeClick()) {
+                Minecraft mc = Minecraft.getInstance();
+                Screen current = mc.screen;
+                if (current == null) {
+                    mc.setScreen(new CharacterEditorScreen());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/acair/acairsoriginssecundus/client/CharacterEditorScreen.java
+++ b/src/main/java/com/acair/acairsoriginssecundus/client/CharacterEditorScreen.java
@@ -1,0 +1,52 @@
+package com.acair.acairsoriginssecundus.client;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Экран простого редактора персонажа.
+ * Здесь пока только фон и кнопка закрытия.
+ * Реальный функционал будет добавлен позже.
+ */
+public class CharacterEditorScreen extends Screen {
+
+    // Фон берем из текстур Origins.
+    private static final ResourceLocation BACKGROUND =
+            new ResourceLocation("acairsoriginssecundus", "origins/textures/gui/choose_origin.png");
+
+    private Button doneButton;
+
+    public CharacterEditorScreen() {
+        super(Component.translatable("screen.acairsoriginssecundus.editor"));
+    }
+
+    @Override
+    protected void init() {
+        int centerX = this.width / 2;
+        int centerY = this.height / 2;
+        // Кнопка закрытия использует стандартный перевод gui.done
+        doneButton = Button.builder(Component.translatable("gui.done"), button -> onClose())
+                .bounds(centerX - 50, centerY + 70, 100, 20)
+                .build();
+        addRenderableWidget(doneButton);
+    }
+
+    @Override
+    public void onClose() {
+        this.minecraft.setScreen(null);
+    }
+
+    @Override
+    public void render(@NotNull GuiGraphics gfx, int mouseX, int mouseY, float partialTicks) {
+        // Отрисовка фона
+        RenderSystem.setShaderTexture(0, BACKGROUND);
+        gfx.blit(BACKGROUND, (this.width - 256) / 2, (this.height - 256) / 2, 0, 0, 256, 256);
+        super.render(gfx, mouseX, mouseY, partialTicks);
+    }
+}


### PR DESCRIPTION
## Summary
- add a main mod class with client initialization
- add simple character editor screen using Origins textures
- register a key binding to open the editor screen

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6843559db7a4832eacb32290ca0b22a8